### PR TITLE
Updated pdftk option from endE to endeast

### DIFF
--- a/cups-epilog.c
+++ b/cups-epilog.c
@@ -1531,7 +1531,7 @@ main(int argc, char *argv[])
             /* Configuration specifies that PDF will be rotated 90 degrees
              * clockwise. Use the program pdftk to rotate the pdf.
              */
-            sprintf(buf, "/usr/bin/pdftk %s cat endE output %s_rotated.pdf",
+            sprintf(buf, "/usr/bin/pdftk %s cat endeast output %s_rotated.pdf",
                     filename_pdf, file_basename);
             /* If debug is enabled then print the command to be executed. */
             if (debug) {


### PR DESCRIPTION
Newer versions of pdftk (e.g. 2.02) use endeast rather than endE as option. See e.g.
http://makandracards.com/makandra/1487-rotate-a-pdf-under-ubuntu-linux.

Note: this is a backward incompatible change; is it ok to assume that users have a recent version of pdftk? I believe yes.